### PR TITLE
Inactivate driver

### DIFF
--- a/app/controllers/drivers_controller.rb
+++ b/app/controllers/drivers_controller.rb
@@ -3,6 +3,7 @@ class DriversController < ApplicationController
 
   def index
     @drivers = @drivers.default_order.for_provider(current_provider.id)
+    @drivers = @drivers.active if params[:active_only] == 'true'
   end
 
   def show

--- a/app/helpers/tracker_action_log_helper.rb
+++ b/app/helpers/tracker_action_log_helper.rb
@@ -85,6 +85,23 @@ module TrackerActionLogHelper
           "Initial mileage was changed to #{mileage[1]} (<b>was:</b> #{mileage[0]}). <br><b>Reason:</b> #{reason}".html_safe
         end
       end
+    when "driver.active_status_changed"
+      driver = log.trackable
+      params = log.parameters || {}
+
+      if driver.present? && !params.blank?
+        msg = ""
+        if params[:prev_active_status_text] != params[:active_status_text]
+          msg += "Active status changed to:<div class='col-sm-12'>#{params[:active_status_text]}</div>" + 
+                "<p style='margin: 0px;'><b>Was: </b></p><div class='col-sm-12'>#{params[:prev_active_status_text]}</div>"+ 
+                "<p style='margin: 0px;'><b>Reason: </b></p><div class='col-sm-12'>#{params[:reason]}</div>"
+        elsif params[:prev_reason] != params[:reason]
+          msg = "Active status:<div class='col-sm-12'>#{params[:active_status_text]}</div>"  +
+                "<p style='margin: 0px;'><b>Reason: </b></p><div class='col-sm-12'>#{params[:reason]}</div>"
+        end
+
+        msg.html_safe
+      end
     end
   end
 end

--- a/app/models/driver.rb
+++ b/app/models/driver.rb
@@ -1,6 +1,7 @@
 class Driver < ActiveRecord::Base
   include RequiredFieldValidatorModule
   include Operatable
+  include PublicActivity::Common
 
   acts_as_paranoid # soft delete
 
@@ -64,6 +65,34 @@ class Driver < ActiveRecord::Base
 
   def user_name
     user.try(:name) || name
+  end
+
+  def inactivated?
+    # permanent inactive
+    # or, inactive for a date range
+    permanent_inactivated? || temporarily_inactivated?
+  end
+
+  def permanent_inactivated?
+    !active
+  end
+
+  def temporarily_inactivated?
+    !permanent_inactivated? && (inactivated_start_date.present? || inactivated_end_date.present?)
+  end
+
+  def active_status_text
+    if !inactivated?
+      "active"
+    elsif permanent_inactivated?
+      "permanently out of service"
+    elsif temporarily_inactivated?
+      if inactivated_end_date.present?
+        "temporarily inactive from #{inactivated_start_date.try(:strftime, '%m/%d/%Y')} to #{inactivated_end_date.try(:strftime, '%m/%d/%Y')}"
+      else
+        "temporarily inactive from #{inactivated_start_date.try(:strftime, '%m/%d/%Y')}"
+      end
+    end
   end
 
   private

--- a/app/models/tracker_action_log.rb
+++ b/app/models/tracker_action_log.rb
@@ -136,6 +136,17 @@ class TrackerActionLog < PublicActivity::Activity
     end
   end
 
+  def self.active_status_changed(driver, user, prev_active_text, prev_reason)
+    return if !driver
+
+    driver.create_activity :active_status_changed, owner: user, params: {
+      prev_active_status_text: prev_active_text,
+      active_status_text: driver.active_status_text,
+      prev_reason: prev_reason || '(not provided)',
+      reason: driver.active_status_changed_reason  || '(not provided)'
+    }  
+  end
+
   private
 
   def self.compare_time_only(time_1, time_2)

--- a/app/views/drivers/_form.html.haml
+++ b/app/views/drivers/_form.html.haml
@@ -50,10 +50,6 @@
                 - if @driver.user.present? && !@driver.user.deleted? && can?(:edit, @driver.user)
                   = link_to translate_helper("edit"), edit_user_path(@driver.user), class: "btn action-button"
           .form-group
-            = f.label :active, translate_helper("driver_form_active"), class: "col-md-2 control-label"
-            .col-md-10
-              = f.select :active, [["Active", "true"], ["Inactive", "false"]], { selected: @driver.active.to_s }, class: "form-control", disabled: @readonly
-          .form-group
             = f.label :paid, translate_helper("paid"), class: "col-md-2 control-label"
             .col-md-10
               = f.select :paid, [["Paid", "true"], ["Volunteer", "false"]], { selected: @driver.paid.to_s }, class: "form-control", disabled: @readonly
@@ -125,11 +121,17 @@
             .panel-footer
               .clearfix
                 = link_to translate_helper("driver_compliances_add_link_title"), new_driver_driver_compliance_path(@driver), class: "btn action-button pull-right", remote: true
+
+        - if @readonly
+          - logs = TrackerActionLog.for(@driver).order(created_at: :desc)
+          = render 'shared/action_log_panel', logs: logs if logs.any?
         / END .panel
     / END .col-md-6
   / END .row
   - unless @readonly
     .row.form-actions= f.submit translate_helper("driver_form_submit"), class: "btn action-button"
+
+= render 'inactivate_dialog' if @readonly 
 = render 'shared/hide_invisible_form_fields_js', model_name: "driver", table_name: 'drivers', provider_id:  current_provider.try(:id)
 = render 'shared/modal_dialog', modal_id: "modal-dialog"
 

--- a/app/views/drivers/_inactivate_dialog.html.haml
+++ b/app/views/drivers/_inactivate_dialog.html.haml
@@ -1,0 +1,86 @@
+#inactivateDialog.modal.fade.col-sm-12{:role => "dialog", "aria-hidden" => 'true', :tabindex => "-1"}
+  .modal-dialog
+    .modal-content
+      = form_for @driver, :url=>driver_inactivate_path(@driver), :html=>{:method=>:post} do |f|
+        .modal-header
+          .pull-right
+            - if @driver.inactivated?
+              = button_tag translate_helper(:activate), id: 'activate_driver', type: :button, style: "margin-right: 5px;", class: "btn action-button btn-danger"
+            = button_tag translate_helper(:submit), type: :submit, style: "margin-right: 5px;", class: "btn action-button"
+            = button_tag class: 'btn action-button', data: {dismiss: 'modal'} do
+              = translate_helper(:cancel)
+          .modal-title{:style => "text-align:left;"}
+            %strong
+              = translate_helper(:configure_inactivation_dialog_title)
+        .modal-body.row{:style => "text-align:left; padding-top: 0px;"}
+          #inactivation_errors.colm-sm-12{style:"display: none;"}
+            %p.alert.alert-danger
+          .col-sm-12
+            .col-sm-12{style: 'padding: 0px;'}
+              %label.col-sm-12
+                = translate_helper('permanent_inactive')
+              .form-group.col-sm-12
+                .col-sm-3
+                  %span= translate_helper(:inactive)
+                .col-sm-9
+                  = f.hidden_field :active
+                  = check_box_tag :permanent_inactive, !@driver.active, !@driver.active
+              %label.col-sm-12
+                = translate_helper('date_range_inactive')
+              .date_range
+                .form-group.col-sm-12
+                  .col-sm-3
+                    %span= translate_helper(:inactivated_start_date)
+                  .col-sm-9
+                    = f.text_field :inactivated_start_date, class: 'date-picker form-control', readonly: true
+                .form-group.col-sm-12
+                  .col-sm-3
+                    %span= translate_helper(:inactivated_end_date)
+                  .col-sm-9
+                    = f.text_field :inactivated_end_date, class: 'date-picker form-control', readonly: true
+            .form-group.col-sm-12{style: 'padding-left: 0px;'}
+              .col-sm-3
+                = f.label :active_status_changed_reason, translate_helper(:active_status_change_reason) 
+              .col-sm-9
+                = f.text_area :active_status_changed_reason, class: 'form-control', maxlength: 30
+
+= render 'shared/date_time_picker_javascript'
+
+:javascript
+  $(function() {
+    makeDatePickers();
+
+    if($('#permanent_inactive').is(':checked')) {
+      $( ".date-picker" ).datepicker( "disable" );
+    }
+
+    $('#permanent_inactive').change(function() {
+      var is_checked = $(this).is(':checked');
+      $('#driver_active').val(!is_checked);
+
+      if(is_checked) {
+        $('.date-picker').val('');
+        $( ".date-picker" ).datepicker( "disable" );
+      } else {
+        $( ".date-picker" ).datepicker( "enable" );
+      }
+    });
+
+    $('#activate_driver').click(function() {
+      $('#permanent_inactive').prop('checked', false);
+      $('#driver_active').val(true);
+      $('.date-picker').val('');
+    });
+
+    $('#inactivateDialog form').submit(function() {
+      var is_inactive = $('#permanent_inactive').is(':checked');
+      var start_date = $( "#driver_inactivated_start_date" ).datepicker('getDate');
+      var end_date = $( "#driver_inactivated_end_date" ).datepicker('getDate');
+      if(!is_inactive && end_date && start_date && end_date < start_date) {
+        $('#inactivation_errors p').html("#{translate_helper(:inactivated_end_date_earlier_than_start_date)}");
+        $('#inactivation_errors').show();
+        return false;
+      }
+    });
+  });
+

--- a/app/views/drivers/index.html.haml
+++ b/app/views/drivers/index.html.haml
@@ -11,7 +11,7 @@
     .checkbox
       %label
         %input#show_active_only{type: 'checkbox'}
-          = translate_helper(:active_only)
+          = translate_helper(:show_inactive)
   .col-sm-12.col-md-6
     %table#documents-table.table.table-striped.table-bordered
       %thead
@@ -31,8 +31,8 @@
 
 :javascript
   $(function() {
-    $('#show_active_only').prop('checked', #{params[:active_only] == 'true'});
+    $('#show_active_only').prop('checked', #{params[:show_inactive] == 'true'});
     $('#show_active_only').change(function() {
-      window.location.href = "#{drivers_path}?active_only=" + $(this).is(':checked')
+      window.location.href = "#{drivers_path}?show_inactive=" + $(this).is(':checked')
     });
   });

--- a/app/views/drivers/index.html.haml
+++ b/app/views/drivers/index.html.haml
@@ -7,6 +7,11 @@
       .pull-right
         = link_to translate_helper("new_driver_link_text"), new_driver_path, class: "btn action-button"
 .row
+  .col-sm-12.pull-right
+    .checkbox
+      %label
+        %input#show_active_only{type: 'checkbox'}
+          = translate_helper(:active_only)
   .col-sm-12.col-md-6
     %table#documents-table.table.table-striped.table-bordered
       %thead
@@ -23,3 +28,11 @@
             %td{:colspan => "5"}= translate_helper("drivers_empty")
         - else
           = render partial: 'driver', collection: @drivers
+
+:javascript
+  $(function() {
+    $('#show_active_only').prop('checked', #{params[:active_only] == 'true'});
+    $('#show_active_only').change(function() {
+      window.location.href = "#{drivers_path}?active_only=" + $(this).is(':checked')
+    });
+  });

--- a/app/views/drivers/show.html.haml
+++ b/app/views/drivers/show.html.haml
@@ -9,4 +9,7 @@
         = link_to translate_helper("delete_driver_button"), @driver, method: :delete, data: { confirm: translate_helper("delete_driver_confirm") }, class: "btn action-button  btn-danger" if can?(:delete, @driver)
         = link_to translate_helper("delete_photo"), delete_photo_driver_path(@driver), data: { confirm: translate_helper("delete_photo_confirm") }, class: "btn action-button btn-danger" if !@driver.new_record? && can?(:edit, @driver) && @driver.photo.present?
         = link_to translate_helper("edit_driver_button"), edit_driver_path(@driver), class: "btn action-button"
+        = button_tag :type => 'button', id: 'inactivateDriver', "data-target" => "#inactivateDialog", "data-toggle" => "modal", :class => "btn action-button btn-danger" do
+          = @driver.inactivated? ? translate_helper(:activate) : translate_helper(:inactivate)
+
 = render partial: "form"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -298,6 +298,7 @@ en:
   driver_address_heading: "Address"
   driver_alt_address_heading: "Alternative Address"
   driver_completed_run_hours: "Completed Run Hours This Week"
+  active_only: 'Active Only?'
 
   # emergency contact
   driver_form_emergency_contact_heading: 'Emergency Contact'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -299,6 +299,15 @@ en:
   driver_alt_address_heading: "Alternative Address"
   driver_completed_run_hours: "Completed Run Hours This Week"
   active_only: 'Active Only?'
+  show_inactive: 'Include inactive?'
+  permanent_inactive: 'Permanent Inactive?'
+  configure_inactivation_dialog_title: 'Configure Inactivation'
+  permanent_inactive: 'Permenent Inactive?'
+  date_range_inactive: 'Inactive for a date range'
+  inactivated_start_date: 'Start Date'
+  inactivated_end_date: 'End Date'
+  active_status_change_reason: 'Reason'
+  inactivated_end_date_earlier_than_start_date: 'End Date should be no earlier than Start Date'
 
   # emergency contact
   driver_form_emergency_contact_heading: 'Emergency Contact'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -148,6 +148,8 @@ Rails.application.routes.draw do
     end
 
     resources :drivers do
+      post :inactivate, :as => :inactivate
+
       member do
         get :delete_photo
         get :check_time_range_availability

--- a/db/migrate/20170601205119_add_inactivated_dates_to_drivers.rb
+++ b/db/migrate/20170601205119_add_inactivated_dates_to_drivers.rb
@@ -1,0 +1,7 @@
+class AddInactivatedDatesToDrivers < ActiveRecord::Migration
+  def change
+    add_column :drivers, :inactivated_start_date, :date
+    add_column :drivers, :inactivated_end_date, :date
+    add_column :drivers, :active_status_changed_reason, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170527212202) do
+ActiveRecord::Schema.define(version: 20170601205119) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -284,7 +284,7 @@ ActiveRecord::Schema.define(version: 20170527212202) do
     t.string   "name"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "lock_version",     default: 0
+    t.integer  "lock_version",                 default: 0
     t.integer  "user_id"
     t.string   "email"
     t.integer  "address_id"
@@ -292,6 +292,9 @@ ActiveRecord::Schema.define(version: 20170527212202) do
     t.string   "phone_number"
     t.integer  "alt_address_id"
     t.string   "alt_phone_number"
+    t.date     "inactivated_start_date"
+    t.date     "inactivated_end_date"
+    t.text     "active_status_changed_reason"
   end
 
   add_index "drivers", ["address_id"], :name => "index_drivers_on_address_id"
@@ -601,6 +604,8 @@ ActiveRecord::Schema.define(version: 20170527212202) do
     t.string   "comments"
     t.integer  "repeating_run_id"
     t.date     "scheduled_through"
+    t.string   "pickup_address_notes"
+    t.string   "dropoff_address_notes"
   end
 
   add_index "repeating_trips", ["customer_id"], :name => "index_repeating_trips_on_customer_id"

--- a/spec/controllers/drivers_controller_spec.rb
+++ b/spec/controllers/drivers_controller_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe DriversController, type: :controller do
       active_driver = create(:driver, :provider => @current_user.current_provider, :active => true)
       inactive_driver = create(:driver, :provider => @current_user.current_provider, :active => false)
       get :index, {show_inactive: 'true'}
-      expect(assigns(:drivers)).to match([active_driver, inactive_driver])
+      expect(assigns(:drivers)).to match_array([active_driver, inactive_driver])
     end
   end
 

--- a/spec/controllers/drivers_controller_spec.rb
+++ b/spec/controllers/drivers_controller_spec.rb
@@ -21,10 +21,24 @@ RSpec.describe DriversController, type: :controller do
 
   describe "GET #index" do
     it "assigns all drivers for the current provider as @drivers" do
-      driver_1 = create(:driver, :provider => @current_user.current_provider)
-      driver_2 = create(:driver)
+      driver_1 = create(:driver, :provider => @current_user.current_provider, :active => true)
+      driver_2 = create(:driver, :active => true)
       get :index, {}
-      expect(assigns(:drivers)).to eq([driver_1])
+      expect(assigns(:drivers)).to match([driver_1])
+    end
+
+    it "default to only active drivers" do
+      active_driver = create(:driver, :provider => @current_user.current_provider, :active => true)
+      inactive_driver = create(:driver, :provider => @current_user.current_provider, :active => false)
+      get :index, {}
+      expect(assigns(:drivers)).to match([active_driver])
+    end
+
+    it "gets all drivers with show_inactive param as true" do
+      active_driver = create(:driver, :provider => @current_user.current_provider, :active => true)
+      inactive_driver = create(:driver, :provider => @current_user.current_provider, :active => false)
+      get :index, {show_inactive: 'true'}
+      expect(assigns(:drivers)).to match([active_driver, inactive_driver])
     end
   end
 


### PR DESCRIPTION
- Ability to mark drivers inactive on a temporary basis.
- The software to have a date range functionality to recognize a driver not available. A comment field for reasons and tracker log action.
- Add checkbox to flag as permanent inactive.
- All permanent out of service drivers hide from active or temp driver list views.
- Check box functionality to show all permanently inactive drivers. Default back to hidden upon log out of Ride Pilot. (Drivers table on Drivers tab main screen)